### PR TITLE
Fix error when attempting to load installed cogs

### DIFF
--- a/redportal/redportal.py
+++ b/redportal/redportal.py
@@ -281,7 +281,7 @@ class Redportal:
         answer = await self.bot.wait_for_message(timeout=15, author=ctx.message.author)
 
         if answer and answer.content.lower() == "yes":
-            self.bot.set_cog("cogs." + cog_name, True)
+            #self.bot.set_cog("cogs." + cog_name, True)
             await ctx.invoke(self.bot.get_cog('Owner').load, cog_name=cog_name)
         else:
             await self.bot.say("Ok then, you can load it with `{}load {}`".format(ctx.prefix, cog_name))

--- a/redportal/redportal.py
+++ b/redportal/redportal.py
@@ -281,7 +281,6 @@ class Redportal:
         answer = await self.bot.wait_for_message(timeout=15, author=ctx.message.author)
 
         if answer and answer.content.lower() == "yes":
-            #self.bot.set_cog("cogs." + cog_name, True)
             await ctx.invoke(self.bot.get_cog('Owner').load, cog_name=cog_name)
         else:
             await self.bot.say("Ok then, you can load it with `{}load {}`".format(ctx.prefix, cog_name))


### PR DESCRIPTION
`set_cog` resides in red.py, not in the bot class, so the current code throws a `AttributeError`
However, I'm not sure why `set_cog` was being called in the first place: the `load` command of the Owner cog is being invoked just after that and that command calls `set_cog` on its own.
@calebj care to clarify?
I'm not able to test my changes at the moment so I'd wait before merging.